### PR TITLE
Add file upload component to forms

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1242,6 +1242,8 @@ func serveFile(c *fiber.Ctx) error {
 			c.Set("Content-Type", "image/svg+xml")
 		case ".webp":
 			c.Set("Content-Type", "image/webp")
+		case ".pdf":
+			c.Set("Content-Type", "application/pdf")
 		default:
 			c.Set("Content-Type", "application/octet-stream")
 		}

--- a/backend/services/file.go
+++ b/backend/services/file.go
@@ -52,8 +52,8 @@ func (fs *FileService) UploadFile(file *multipart.FileHeader, userID string, for
 		return nil, fmt.Errorf("invalid file type: %s", file.Header.Get("Content-Type"))
 	}
 
-	// Validate file size (10MB limit)
-	const maxFileSize = 10 << 20 // 10MB
+	// Validate file size (15MB limit)
+	const maxFileSize = 15 << 20 // 15MB
 	if file.Size > maxFileSize {
 		return nil, fmt.Errorf("file too large: %d bytes (max: %d bytes)", file.Size, maxFileSize)
 	}

--- a/frontend/src/app/components/field-toolbox.tsx
+++ b/frontend/src/app/components/field-toolbox.tsx
@@ -9,6 +9,7 @@ import {
   Star,
   Calendar,
   PenTool,
+  Paperclip,
 } from "lucide-react";
 
 interface FieldToolboxProps {
@@ -22,6 +23,7 @@ interface FieldToolboxProps {
       | "rating"
       | "date"
       | "signature"
+      | "file"
   ) => void;
 }
 
@@ -35,6 +37,7 @@ export function FieldToolbox({ onAddField }: FieldToolboxProps) {
     { type: "rating" as const, label: "Rating", icon: Star },
     { type: "date" as const, label: "Date Picker", icon: Calendar },
     { type: "signature" as const, label: "Signature Pad", icon: PenTool },
+    { type: "file" as const, label: "File Upload", icon: Paperclip },
   ];
 
   return (

--- a/frontend/src/app/components/form-builder.tsx
+++ b/frontend/src/app/components/form-builder.tsx
@@ -33,6 +33,9 @@ export function FormBuilder({ formData, onFormDataChange }: FormBuilderProps) {
       ...(type === "select" || type === "radio" || type === "checkbox"
         ? { options: ["Option 1", "Option 2"] }
         : {}),
+      ...(type === "file"
+        ? { fileOptions: { accept: "*/*", multiple: false, maxSize: 15 } }
+        : {}),
     };
 
     console.log("FormBuilder: Adding new field:", newField);

--- a/frontend/src/app/components/form-field.tsx
+++ b/frontend/src/app/components/form-field.tsx
@@ -125,6 +125,14 @@ export function FormField({
             />
           </div>
         );
+      case "file":
+        return (
+          <div className="pointer-events-none">
+            <div className="border-2 border-dashed rounded-lg p-6 text-center text-sm text-muted-foreground">
+              File upload area (preview)
+            </div>
+          </div>
+        );
       default:
         return null;
     }
@@ -239,6 +247,60 @@ export function FormField({
                     <Plus className="h-4 w-4 mr-2" />
                     Add Option
                   </Button>
+                </div>
+              </div>
+            )}
+
+            {field.type === "file" && (
+              <div className="space-y-3">
+                <div>
+                  <Label>Accepted types (MIME or extensions)</Label>
+                  <Input
+                    value={field.fileOptions?.accept || "*/*"}
+                    onChange={(e) =>
+                      onUpdate({
+                        fileOptions: {
+                          accept: e.target.value,
+                          multiple: field.fileOptions?.multiple || false,
+                          maxSize: field.fileOptions?.maxSize || 15,
+                        },
+                      })
+                    }
+                    placeholder="e.g. image/*,application/pdf"
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label>Allow multiple files</Label>
+                  <Switch
+                    checked={field.fileOptions?.multiple || false}
+                    onCheckedChange={(checked: boolean) =>
+                      onUpdate({
+                        fileOptions: {
+                          accept: field.fileOptions?.accept || "*/*",
+                          multiple: checked,
+                          maxSize: field.fileOptions?.maxSize || 15,
+                        },
+                      })
+                    }
+                  />
+                </div>
+                <div>
+                  <Label>Max size (MB)</Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={100}
+                    value={field.fileOptions?.maxSize ?? 15}
+                    onChange={(e) =>
+                      onUpdate({
+                        fileOptions: {
+                          accept: field.fileOptions?.accept || "*/*",
+                          multiple: field.fileOptions?.multiple || false,
+                          maxSize: Number(e.target.value) || 15,
+                        },
+                      })
+                    }
+                  />
                 </div>
               </div>
             )}

--- a/frontend/src/app/components/public-form.tsx
+++ b/frontend/src/app/components/public-form.tsx
@@ -378,7 +378,7 @@ export function PublicForm({
               fieldId={field.id}
               accept={field.fileOptions?.accept || "*/*"}
               multiple={field.fileOptions?.multiple || false}
-              maxSize={field.fileOptions?.maxSize || 10}
+              maxSize={field.fileOptions?.maxSize || 15}
               onFileChange={(hasFile, fileUrl, filename) => {
                 // Store the file URL or an array of URLs for multiple files
                 if (hasFile && fileUrl) {

--- a/frontend/src/app/components/responses-view.tsx
+++ b/frontend/src/app/components/responses-view.tsx
@@ -319,7 +319,7 @@ export function ResponsesView({ form, onBack }: ResponsesViewProps) {
                 </TableHeader>
                 <TableBody>
                   {responses.map((response) => (
-                    <TableRow key={response.id}>
+                    <TableRow key={response.id} onClick={() => setSelectedResponse(response)} className="cursor-pointer">
                       <TableCell>
                         {format(
                           new Date(response.createdAt),

--- a/frontend/src/app/components/ui/file-upload.tsx
+++ b/frontend/src/app/components/ui/file-upload.tsx
@@ -28,7 +28,7 @@ export function FileUpload({
   fieldId,
   accept = "*/*",
   multiple = false,
-  maxSize = 10
+  maxSize = 15
 }: FileUploadProps) {
   const [uploadedFiles, setUploadedFiles] = useState<Array<{ url: string; filename: string; id: string }>>([]);
   const [isUploading, setIsUploading] = useState(false);


### PR DESCRIPTION
Add a 'File Upload' field type to forms, allowing users to upload files up to 15MB, viewable in form responses and the files page.

---
<a href="https://cursor.com/background-agent?bcId=bc-cae96036-3e41-4791-896d-ff40fa952c01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cae96036-3e41-4791-896d-ff40fa952c01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

